### PR TITLE
Review of repo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,13 +15,15 @@
 				"ms-vscode.cpptools-extension-pack"
 			]
 		}
-	}
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+	"forwardPorts": [
+		50051
+	]
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "cat /etc/os-release",

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,20 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag sfincs-bmi-server:$(date +%s)
+    # TODO check that image works by starting it and running example code
+    # TODO and publish image to ghcr.io, see 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,3 +57,5 @@ RUN cmake .. && make install && ldconfig
 # Expose entrypoint
 ENV BMI_PORT=50051
 ENTRYPOINT ["/usr/local/bin/sfincs_bmi_server"]
+
+LABEL org.opencontainers.image.source https://github.com/eWaterCycle/sfincs-bmi-server

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ cd src
 mkdir build
 cmake ..
 make
-# Produces a `./sfincs_bmi_server` executable.
+# Start gprc server
 ./sfincs_bmi_server
 ```
 
-To interact with it through a grpc4bmi client:
+To interact with grpc server through a grpc4bmi client:
 
 ```py
 import grpc

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ an older version of the BMI spec.
 
 Build docker image with
 
-```
-cd src
+```shell
 docker build -t sfincs-bmiserver .
 ```
 
@@ -32,6 +31,8 @@ from grpc4bmi.bmi_client_docker import BmiClientDocker
 model = BmiClientDocker(image='sfincs-bmiserver', image_port=50051, work_dir="./")
 model.get_component_name()
 # 'Sfincs hydrodynamic model (C)'
+
+del model
 ```
 
 See the example notebook shipped with this repo.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ an older version of the BMI spec.
 
 ## Using it
 
+Pull image from https://github.com/eWaterCycle/sfincs-bmi-server/pkgs/container/sfincs-bmiserver or
+
 Build docker image with
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -47,3 +47,35 @@ vscode, install the devcontainers extension, then from the command pallete
 choose "Dev Containers: Open Folder in Container". This will build the container
 mount your working directory, and open the remote environment in vscode. The c++
 and docker extensions are automatically be loaded.
+
+To rebuild the server without rebuilding Docker image use
+
+```sh
+cd src
+mkdir build
+cmake ..
+make
+# Produces a `./sfincs_bmi_server` executable.
+./sfincs_bmi_server
+```
+
+To interact with it through a grpc4bmi client:
+
+```py
+import grpc
+from grpc4bmi.bmi_grpc_client import BmiClient
+
+model = BmiClient(grpc.insecure_channel("localhost:50051"))
+
+model.get_component_name()
+# 'Sfincs hydrodynamic model (C)'
+```
+
+## Publish image
+
+After build, publish image to https://github.com/orgs/eWaterCycle/packages with
+
+```shell
+docker tag sfincs-bmiserver ghcr.io/ewatercycle/sfincs-bmiserver:sfincs-v2.0.2-Blockhaus-Release-Q2-2023
+docker push ghcr.io/ewatercycle/sfincs-bmiserver:sfincs-v2.0.2-Blockhaus-Release-Q2-2023
+```


### PR DESCRIPTION
Nice work, making the wrapper code, image and dev container.

* I tested the dev container and it worked
  * files are created as root, making hard to use outside container. Possible workaround is to add a user, see for example https://github.com/EcoExtreML/STEMMUS_SCOPE/blob/main/.devcontainer/Dockerfile
* The example in readme worked
* Tried to run notebook using [example](https://github.com/Deltares/hydromt_sfincs/tree/main/examples) in https://github.com/eWaterCycle/sfincs-bmi-server/tree/example-case-notebook branch, was able to call update and get_current_time, but other methods are not implemented yet. I made separate branch as changes are a bit bigger than this PR.

It would be nice to have 2 different Dockerfiles:
1. for production, stripped of all compilers, cloned repos etc.
2. for development, with all stuff needed to develop like grpc4bmi Python installed.

I added somethings that I felt are handy.

